### PR TITLE
New ore thinning distribution, small optimizations

### DIFF
--- a/mods/fracturerift/init.lua
+++ b/mods/fracturerift/init.lua
@@ -74,8 +74,9 @@ minetest.register_on_generated(function(minp, maxp, seed)
    
    for z = z0, z1 do -- for each xy plane progressing northwards
      for y = y0, y1 do -- for each x row progressing upwards
+		vi = area:index(x0, y, z) --This accesses the node at a given position.  vi is incremented inside the loop for greater performance.
        for x = x0, x1 do -- for each node do
-			local vi = area:index(x, y, z) -- This accesses the node at a given position
+			--local vi = area:index(x, y, z) -- This accesses the node at a given position
 		 
 			local grad = math.abs(x / fracrift_edge) * (10^(math.abs(x / fracrift_edge)) / 10) -- Density gradient.  This controls how much to offset the noise value as x approaches the walls of the chasm.
 		 
@@ -102,14 +103,15 @@ minetest.register_on_generated(function(minp, maxp, seed)
 			end -- if x > -fracrift_edge and x < fracrift_edge
 		 
 			if x == -fracrift_edge or x == fracrift_edge then  -- x is on edge
-				if data[vi] == c_water and math.random() < fracrift_waterfallchance and (math.abs(nvals_walls[nixyz]) - grad) > 0 then
+				if data[vi] == c_water and math.random() < fracrift_waterfallchance and (math.abs(nvals_walls[nixyz]) - grad) > -0.1 then
 					data[vi]=fracrift_material
 					changed=true
 				end -- change water to stone on edge
 			end -- if x == -fracrift_edge or x == fracrift_edge
 		 
 			nixyz = nixyz + 1
-		 
+			vi = vi + 1
+			
        end -- end 'x' loop
      end -- end 'y' loop
    end -- end 'z' loop

--- a/mods/orethinning/init.lua
+++ b/mods/orethinning/init.lua
@@ -93,7 +93,8 @@ minetest.register_on_generated(function(minp, maxp, seed)
    if dist > orethin_maxdist then
      dist=orethin_maxdist
    end --orethin_maxdist
-   local adj=(dist/orethin_maxdist)
+   local adj= (orethin_maxdist/(1+(orethin_maxdist-1)* math.exp(-.0075*dist))) / orethin_maxdist --(dist/orethin_maxdist)--original code.  
+		--New code makes ore thin until about 1000 nodes away, and then it rapidly gets more common.  To adjust distribution, change the value currently at -.0075. Closer to 0 is more thinning, greater negative numbers are less thinning.
    if adj < orethin_mindensity then
      adj=orethin_mindensity    --because we don't want spawn completely bare
     end --min adj
@@ -110,8 +111,9 @@ minetest.register_on_generated(function(minp, maxp, seed)
    for z = z0, z1 do -- for each xy plane progressing northwards
       for y = y0, y1 do -- for each x row progressing upwards
          --local vi = area:index(x0, y, z) -- This accesses the node at a given position
+		 local vi = area:index(x0, y, z) --Switched to incrementing form for slight speed increase.
          for x = x0, x1 do -- for each node do
-            local vi = area:index(x, y, z) -- This accesses the node at a given position
+            --local vi = area:index(x, y, z) -- This accesses the node at a given position
             --x>0 is east, so we exclude ores in the west only list
             --cant search arrays that way when the elements are numbers.
             --if x > 0 and orethin_westlist.data[vi] then
@@ -139,6 +141,7 @@ minetest.register_on_generated(function(minp, maxp, seed)
                   changed=true
                end
             end -- end ore existence check
+			vi = vi + 1 --increment the LVM index
          end -- end 'x' loop
       end -- end 'y' loop
    end -- end 'z' loop


### PR DESCRIPTION
Ore thinning now has a different distribution that heavily thins for the
first 1000 nodes before rapidly becoming abundant.  Fixed water spilling
in places with fracturerift, and optimized some indexing for a miniscule
speed increase.
